### PR TITLE
the print results was combining upload and download due to same list

### DIFF
--- a/src/com/takipi/tests/speedtest/SpeedTest.java
+++ b/src/com/takipi/tests/speedtest/SpeedTest.java
@@ -96,9 +96,10 @@ public class SpeedTest
 	{
 		for (Region region : Region.values())
 		{
-			List<Long> list = new ArrayList<Long>();
-			this.uploadTimings.put(region, list);
-			this.downloadTimings.put(region, list);
+			List<Long> upList = new ArrayList<Long>();
+			this.uploadTimings.put(region, upList);
+			List<Long> downList = new ArrayList<Long>();
+			this.downloadTimings.put(region, downList);
 		}
 		
 		S3Manager.initBuckets(false);


### PR DESCRIPTION
Great work.  I was just using it to test some stuff and kept seeing the results including too many points for the rounds chosen.  Looks like the for the region it is combining the upload and download items.

Matt
